### PR TITLE
Private ip address returned by the server

### DIFF
--- a/lib/double_bag_ftps.rb
+++ b/lib/double_bag_ftps.rb
@@ -93,6 +93,8 @@ class DoubleBagFTPS < Net::FTP
     if @passive
       host, port = makepasv
 
+      host = @hostname if Addrinfo.ip(host).ipv4_private?
+
       if @resume and rest_offset
         resp = sendcmd('REST ' + rest_offset.to_s)
         if resp[0] != ?3


### PR DESCRIPTION
fix to return the original host ip address if
one private address is being returned by the server..

Fix #2
