### PR TITLE
Active mode data transfers do not hang

### DIFF
--- a/lib/double_bag_ftps.rb
+++ b/lib/double_bag_ftps.rb
@@ -121,10 +121,9 @@ class DoubleBagFTPS < Net::FTP
       if resp[0] != ?1
         raise FTPReplyError, resp
       end
-
-      temp_ssl_sock = ssl_socket(sock)
-      conn = temp_ssl_sock.accept
-      temp_ssl_sock.close
+      conn = sock.accept
+      conn = ssl_socket(conn)
+      sock.close
     end
     return conn
   end


### PR DESCRIPTION
This is a fix for issue https://github.com/bnix/double-bag-ftps/issues/4

No direct test.  Currently tested via https://github.com/wconrad/ftpd 's tests, which use double-bag-ftps to drive ftpd.

Also manually tested against pure-ftpd.
