### PR TITLE
Reuse previous ssl session

### DIFF
--- a/lib/double_bag_ftps.rb
+++ b/lib/double_bag_ftps.rb
@@ -143,12 +143,16 @@ class DoubleBagFTPS < Net::FTP
   def ssl_socket(sock)
     raise 'SSL extension not installed' unless defined?(OpenSSL)
     sock = OpenSSL::SSL::SSLSocket.new(sock, @ssl_context)
+    if @ssl_session
+      sock.session = @ssl_session
+    end
     sock.sync_close = true
     sock.connect
     print "get: #{sock.peer_cert.to_text}" if @debug_mode
     unless @ssl_context.verify_mode == OpenSSL::SSL::VERIFY_NONE
       sock.post_connection_check(@hostname)
     end
+    @ssl_session = sock.session
     decorate_socket sock
     return sock
   end


### PR DESCRIPTION
Version 0.1.1 has an issue when connecting to FTPS servers that are required to exhibit SSL session reuse.  When retrieving a file after connecting, the following message appears:

```
522 SSL connection failed; session reuse required: see require_ssl_reuse 
option in vsftpd.conf man page (Net::FTPPermError)
```

I copied this fix from https://github.com/alain75007/double-bag-ftps/commit/5aefbb7daeb24173993467326763fbf24ae72d39 since that fork doesn't seem to work with Ruby 2.0.
