### PR TITLE
active mode transfers work in ruby-2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+## 0.1.3
+
+Bugfixes:
+
+  - Active mode transfers send proper commands with Ruby > 2.2.2
+
 ## 0.1.2
+
 Bugfixes:
 
   - Reuse SSL session when creating new sockets

--- a/double_bag_ftps.gemspec
+++ b/double_bag_ftps.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "double-bag-ftps"
-  s.version     = "0.1.2"
+  s.version     = "0.1.3"
   s.license     = "MIT"
   s.author      = "Bryan Nix"
   s.homepage    = "https://github.com/bnix/double-bag-ftps"

--- a/lib/double_bag_ftps.rb
+++ b/lib/double_bag_ftps.rb
@@ -109,6 +109,10 @@ class DoubleBagFTPS < Net::FTP
       conn = ssl_socket(conn) # SSL connection now possible after cmd sent
     else
       sock = makeport
+      # Before ruby-2.3.0, makeport did a sendport automatically
+      if RUBY_VERSION >= "2.3"
+        sendport(sock.addr[3], sock.addr[1])
+      end
       if @resume and rest_offset
         resp = sendcmd('REST ' + rest_offset.to_s)
         if resp[0] != ?3

--- a/lib/double_bag_ftps.rb
+++ b/lib/double_bag_ftps.rb
@@ -1,4 +1,5 @@
 require 'net/ftp'
+require 'rubygems'
 begin
   require 'openssl'
 rescue LoadError
@@ -109,8 +110,8 @@ class DoubleBagFTPS < Net::FTP
       conn = ssl_socket(conn) # SSL connection now possible after cmd sent
     else
       sock = makeport
-      # Before ruby-2.3.0, makeport did a sendport automatically
-      if RUBY_VERSION >= "2.3"
+      # Before ruby-2.2.3, makeport did a sendport automatically
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.3")
         sendport(sock.addr[3], sock.addr[1])
       end
       if @resume and rest_offset


### PR DESCRIPTION
# The symptom

Active mode file transfers do not work in Ruby 2.3.0, 2.2.3, and 2.2.4.  The reason is that the PORT command is no longer sent.

With ruby 2.2, calling a file transfer method such as #gettextfile, when in active mode, causes this sequence of FTP commands:

    TYPE A
    PORT 127,0,0,1,175,206
    RETR ascii_unix
    TYPE I

With Ruby 2.3, the sequence is missing the PORT command:

    TYPE A
    200 Type set to A
    RETR ascii_unix

# The cause

As it necessarily does, double-bag-ftps is bound to the internals of Ruby's ftp class.  In Ruby 2.3.0, one of those internals has changed in a way that breaks active mode file transfers: the #makeport method no longer automatically invokes #sendport.  #sendport is what sends the PORT command to the server.

# The fix

This patch explicitly issues the sendport command for ruby-2.3 or later.

With this patch, https://github.com/wconrad/ftpd/tree/ruby-2.3 passes its tests for these ruby versions:

* 1.9.3
* 2.1.5
* 2.2.0
* 2.2.1
* 2.2.2
* 2.2.3
* 2.2.4
* 2.3.0
