### PR TITLE
Only close the ftp connection if it's open

### DIFF
--- a/lib/double_bag_ftps.rb
+++ b/lib/double_bag_ftps.rb
@@ -30,7 +30,7 @@ class DoubleBagFTPS < Net::FTP
       begin
         yield ftps
       ensure
-        ftps.close
+        ftps.close unless ftps.closed?
       end
     else
       new(host, user, passwd, acct, ftps_mode, ssl_context_params)


### PR DESCRIPTION
If an error occured causing the connection to not be opened, this close will trigger an additional exception, as we can't close a closed socket.

```
/usr/local/Cellar/ruby/2.3.1/lib/ruby/2.3.0/net/ftp.rb:114:in `read_timeout=': undefined method `read_timeout=' for #<TCPSocket:(closed)> (NoMethodError)
Did you mean?  readline
    from /usr/local/Cellar/ruby/2.3.1/lib/ruby/2.3.0/net/ftp.rb:1175:in `ensure in close'
    from /usr/local/Cellar/ruby/2.3.1/lib/ruby/2.3.0/net/ftp.rb:1175:in `close'
    from /usr/local/lib/ruby/gems/2.3.0/gems/double-bag-ftps-0.1.3/lib/double_bag_ftps.rb:33:in `ensure in open'
    from /usr/local/lib/ruby/gems/2.3.0/gems/double-bag-ftps-0.1.3/lib/double_bag_ftps.rb:33:in `open'
```

This change makes sure we only close connections if they are open.
