### PR TITLE
Apply sendport fix to ruby 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Development
+## 0.1.4
 
 Buffixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+## Development
+
+Buffixes:
+
+- Fix active mode transfers hanging in some versions of Ruby 2.1
+
 ## 0.1.3
 
 Bugfixes:
 
-  - Active mode transfers send proper commands with Ruby > 2.2.2
+- Fix active mode transfers hanging in some versions of Ruby 2.2 and
+  2.3
 
 ## 0.1.2
 

--- a/double_bag_ftps.gemspec
+++ b/double_bag_ftps.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "double-bag-ftps"
-  s.version     = "0.1.3"
+  s.version     = "0.1.4"
   s.license     = "MIT"
   s.author      = "Bryan Nix"
   s.homepage    = "https://github.com/bnix/double-bag-ftps"


### PR DESCRIPTION
Active mode transfers hang in ruby-2.1.7 through ruby-2.1.10.  This is the same problem as #12, which applied the fix to ruby-2.2.X and ruby.2.3.X.  Since then, the Ruby maintainers have made the same modification to the Ruby ftp library, starting with ruby-2.1.7.

@bnix This is tested and ready to go.  Please release a new gem when you can--I've already updated the change log and bumped the gem version.
