### PR TITLE
 Adds docker-compose method for running tests locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: ruby
+sudo: false
+
+script: rspec
+
+rvm:
+  - 2.2
+  - 2.3
+
+before_install:
+  # Install ftp server
+  - sudo apt-get -qq update
+  - sudo apt-get install -y vsftpd
+
+  # Create a test user
+  - sudo useradd ftptest -s /bin/bash -m
+  - echo ftptest:ftppass | sudo chpasswd
+
+  # Create a test file
+  - echo "Hello, world!" | sudo -u ftptest tee -a /home/ftptest/testfile
+
+  # Allow ascii access
+  - echo "ascii_download_enable=YES" | sudo tee -a /etc/vsftpd.conf
+  # Configure default server for explicit ftps
+  - echo "ssl_enable=Yes" | sudo tee -a /etc/vsftpd.conf
+
+  - sudo restart vsftpd
+
+  # Configure and run a second server for implicit ftps
+  - cat /etc/vsftpd.conf
+  - sudo vsftpd /etc/vsftpd.conf -oimplicit_ssl=YES -olisten_port=990 &

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.3
+
+RUN mkdir -p /gem
+WORKDIR /gem
+
+ADD . ./
+
+RUN gem install bundler && bundle install --jobs 20 --retry 5

--- a/Dockerfile-ftps
+++ b/Dockerfile-ftps
@@ -1,0 +1,45 @@
+FROM ubuntu:trusty
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -qq update
+RUN apt-get install -y openssl vsftpd
+
+RUN mkdir -p /etc/ssl/private
+RUN openssl dhparam -out /etc/ssl/private/vsftpd-dhparams.pem 2048
+RUN openssl req -x509 -nodes -newkey rsa:2048 -sha256 \
+    -keyout /etc/ssl/private/vsftpd.pem \
+    -out /etc/ssl/private/vsftpd.pem \
+    -subj "/C=US/ST=Virginia/CN=example.com"
+RUN chmod 600 /etc/ssl/private/*.pem
+
+# Create a test user
+RUN useradd ftptest -s /bin/bash -m
+RUN echo ftptest:ftppass | chpasswd
+
+# Install certificates
+RUN echo "rsa_cert_file=/etc/ssl/private/vsftpd.pem" | tee -a /etc/vsftpd.conf
+RUN echo "rsa_private_key_file=/etc/ssl/private/vsftpd.pem" | tee -a /etc/vsftpd.conf
+
+# Allow ascii access
+RUN echo "ascii_download_enable=YES" | tee -a /etc/vsftpd.conf
+
+# Configure default server for explicit ftps
+RUN echo "ssl_enable=YES" | tee -a /etc/vsftpd.conf
+
+# Enable logging
+RUN touch /var/log/vsftpd.log
+RUN echo "vsftpd_log_file=/var/log/vsftpd.log" | tee -a /etc/vsftpd.conf
+RUN echo "log_ftp_protocol=YES" | tee -a /etc/vsftpd.conf
+
+# Disable secure_chroot_dir
+# secure_chroot_dir=/var/run/vsftpd/empty
+RUN sed '/secure_chroot_dir/s/^/#/g' /etc/vsftpd.conf
+
+RUN mkdir -p /var/share/empty
+RUN echo "secure_chroot_dir=/var/share/empty" | tee -a /etc/vsftpd.conf
+
+COPY ./docker-ftps-entrypoint.sh /
+CMD ["/docker-ftps-entrypoint.sh"]
+
+EXPOSE 21 990 30000-30009

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ Interface
     ftps_explicit?
     ftps_implicit?
 
+Running Tests Inside using `docker-compose`
+-------------------------------------------
+
+```
+docker-compose build
+docker-compose run gem rspec
+```
+
+This will start a Docker container which is set up to accept implicit and explicit connections.
+
+This container's configuration should be very similar to that used by TravisCI.
+
 More Information
 ----------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  gem:
+    build: .
+    depends_on:
+      - ftps
+    volumes:
+      - .:/gem
+      - bundler:/usr/local/bundle
+  ftps:
+    build:
+      context: .
+      dockerfile: Dockerfile-ftps
+    ports:
+      - "21:21"
+      - "990:990"
+    volumes:
+      - ./tmp/ftp_root:/home/ftptest
+    environment:
+      PUBLICHOST: ftps
+
+volumes:
+  bundler:

--- a/docker-ftps-entrypoint.sh
+++ b/docker-ftps-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+vsftpd /etc/vsftpd.conf -oimplicit_ssl=YES -olisten_port=990 &
+vsftpd /etc/vsftpd.conf

--- a/spec/double_bag_ftps_spec.rb
+++ b/spec/double_bag_ftps_spec.rb
@@ -24,7 +24,7 @@ shared_examples_for "DoubleBagFTPS" do
       filename.should_not be_nil
       local_path = File.join(temp_dir, filename)
       @ftp.get(filename, local_path)
-      File.exists?(local_path).should be_true
+      File.exists?(local_path).should be true
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,10 @@ require 'double_bag_ftps'
 
 require 'tmpdir'
 
-HOST   = 'localhost'
+if ENV['TRAVIS'] == 'true'
+  HOST   = 'localhost'
+else
+  HOST   = 'ftps'
+end
 USR    = 'ftptest'
 PASSWD = 'ftppass'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,6 @@ require 'double_bag_ftps'
 
 require 'tmpdir'
 
-HOST   = 'ftp.secureftp-test.com'
-USR    = 'test'
-PASSWD = 'test'
+HOST   = 'localhost'
+USR    = 'ftptest'
+PASSWD = 'ftppass'

--- a/tmp/ftp_root/testfile
+++ b/tmp/ftp_root/testfile
@@ -1,0 +1,1 @@
+Hello, World


### PR DESCRIPTION
This pull request builds on the Travis-based FTP configuration from #19, and creates a similarly configured Docker container that that can be run with `docker-compose`.